### PR TITLE
Make titles and action public

### DIFF
--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -95,7 +95,12 @@ public class YSSegmentedControl: UIView {
         }
     }
     
-    var titles: [String]!
+    public var titles: [String]! {
+        didSet {
+            self.draw()
+        }
+    }
+    
     var items: [YSSegmentedControlItem]!
     var selector: UIView!
     

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -97,7 +97,12 @@ public class YSSegmentedControl: UIView {
     
     public var titles: [String]! {
         didSet {
-            self.draw()
+            if appearance == nil {
+                defaultAppearance()
+            }
+            else {
+                self.draw()
+            }
         }
     }
     

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -87,7 +87,7 @@ public class YSSegmentedControl: UIView {
     // MARK: Properties
     
     weak var delegate: YSSegmentedControlDelegate?
-    var action: YSSegmentedControlAction?
+    public var action: YSSegmentedControlAction?
     
     public var appearance: YSSegmentedControlAppearance! {
         didSet {


### PR DESCRIPTION
This pull request changes the `titles` and `action` properties to be public, allowing users of `YSSegmentedControl` to update the titles and action.

When `titles` is set, the `YSSegmentedControl` will redraw itself.
