### PR TITLE
Implement layoutSubviews

### DIFF
--- a/YSSegmentedControl.xcodeproj/project.pbxproj
+++ b/YSSegmentedControl.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = YSSegmentedControl/Info.plist;
+				INFOPLIST_FILE = YSSegmentedControl/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -376,7 +376,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = YSSegmentedControl/Info.plist;
+				INFOPLIST_FILE = YSSegmentedControl/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -141,6 +141,8 @@ public class YSSegmentedControl: UIView {
             let v = sub
             v.removeFromSuperview()
         }
+        
+        items.removeAll()
     }
     
     private func draw () {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -95,7 +95,12 @@ public class YSSegmentedControl: UIView {
         }
     }
     
-    var titles: [String]!
+    public var titles: [String]! {
+        didSet {
+            self.draw()
+        }
+    }
+    
     var items: [YSSegmentedControlItem]!
     var selector: UIView!
     

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -46,15 +46,26 @@ class YSSegmentedControlItem: UIControl {
         appearance: YSSegmentedControlAppearance,
         willPress: YSSegmentedControlItemAction?,
         didPressed: YSSegmentedControlItemAction?) {
-            super.init(frame: frame)
-            self.willPress = willPress
-            self.didPressed = didPressed
-            label = UILabel(frame: CGRect(x: 0, y: 0, width: frame.size.width, height: frame.size.height))
-            label.textColor = appearance.textColor
-            label.font = appearance.font
-            label.textAlignment = .Center
-            label.text = text
-            addSubview(label)
+        super.init(frame: frame)
+        self.willPress = willPress
+        self.didPressed = didPressed
+        label = UILabel(frame: CGRectZero)
+        label.textColor = appearance.textColor
+        label.font = appearance.font
+        label.textAlignment = .Center
+        label.text = text
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        
+        let views = ["label": label]
+        addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[label]|",
+            options: [],
+            metrics: nil,
+            views: views))
+        addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[label]|",
+            options: [],
+            metrics: nil,
+            views: views))
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -117,8 +117,9 @@ public class YSSegmentedControl: UIView {
         }
     }
     
-    var selector: UIView!
     var items = [YSSegmentedControlItem]()
+    var selector = UIView(frame: CGRectZero)
+    var bottomLine = CALayer()
     
     // MARK: Init
     
@@ -145,15 +146,9 @@ public class YSSegmentedControl: UIView {
     private func draw () {
         reset()
         backgroundColor = appearance.backgroundColor
-        let width = frame.size.width / CGFloat(titles.count)
-        var currentX: CGFloat = 0
         for title in titles {
             let item = YSSegmentedControlItem(
-                frame: CGRect(
-                    x: currentX,
-                    y: appearance.labelTopPadding,
-                    width: width,
-                    height: frame.size.height - appearance.labelTopPadding),
+                frame: CGRectZero,
                 text: title,
                 appearance: appearance,
                 willPress: { segmentedControlItem in
@@ -169,27 +164,46 @@ public class YSSegmentedControl: UIView {
             })
             addSubview(item)
             items.append(item)
-            currentX += width
         }
         // bottom line
-        let bottomLine = CALayer ()
+        bottomLine.backgroundColor = appearance.bottomLineColor.CGColor
+        layer.addSublayer(bottomLine)
+        // selector
+        selector.backgroundColor = appearance.selectorColor
+        addSubview(selector)
+        
+        selectItemAtIndex(0, withAnimation: true)
+        
+        setNeedsLayout()
+    }
+    
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        let width = frame.size.width / CGFloat(titles.count)
+        var currentX: CGFloat = 0
+        
+        for item in items {
+            item.frame = CGRect(
+                x: currentX,
+                y: appearance.labelTopPadding,
+                width: width,
+                height: frame.size.height - appearance.labelTopPadding)
+            currentX += width
+        }
+        
         bottomLine.frame = CGRect(
             x: 0,
             y: frame.size.height - appearance.bottomLineHeight,
             width: frame.size.width,
             height: appearance.bottomLineHeight)
-        bottomLine.backgroundColor = appearance.bottomLineColor.CGColor
-        layer.addSublayer(bottomLine)
-        // selector
-        selector = UIView (frame: CGRect (
-            x: 0,
+        
+        selector.frame = CGRect (
+            x: selector.frame.origin.x,
             y: frame.size.height - appearance.selectorHeight,
             width: width,
-            height: appearance.selectorHeight))
-        selector.backgroundColor = appearance.selectorColor
-        addSubview(selector)
+            height: appearance.selectorHeight)
         
-        selectItemAtIndex(0, withAnimation: true)
     }
     
     private func defaultAppearance () {
@@ -228,14 +242,14 @@ public class YSSegmentedControl: UIView {
         let width = frame.size.width / CGFloat(items.count)
         let target = width * CGFloat(index)
         UIView.animateWithDuration(withAnimation ? 0.3 : 0,
-            delay: 0,
-            usingSpringWithDamping: 1,
-            initialSpringVelocity: 0,
-            options: [],
-            animations: {
-                [unowned self] in
-                self.selector.frame.origin.x = target
+                                   delay: 0,
+                                   usingSpringWithDamping: 1,
+                                   initialSpringVelocity: 0,
+                                   options: [],
+                                   animations: {
+                                    [unowned self] in
+                                    self.selector.frame.origin.x = target
             },
-            completion: nil)
+                                   completion: nil)
     }
 }

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -97,7 +97,12 @@ public class YSSegmentedControl: UIView {
     
     public var titles: [String]! {
         didSet {
-            self.draw()
+            if appearance == nil {
+                defaultAppearance()
+            }
+            else {
+                self.draw()
+            }
         }
     }
     

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -117,8 +117,8 @@ public class YSSegmentedControl: UIView {
         }
     }
     
-    var items: [YSSegmentedControlItem]!
     var selector: UIView!
+    var items = [YSSegmentedControlItem]()
     
     // MARK: Init
     
@@ -140,7 +140,6 @@ public class YSSegmentedControl: UIView {
             let v = sub
             v.removeFromSuperview()
         }
-        items = []
     }
     
     private func draw () {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -87,7 +87,7 @@ public class YSSegmentedControl: UIView {
     // MARK: Properties
     
     weak var delegate: YSSegmentedControlDelegate?
-    var action: YSSegmentedControlAction?
+    public var action: YSSegmentedControlAction?
     
     public var appearance: YSSegmentedControlAppearance! {
         didSet {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -49,11 +49,22 @@ class YSSegmentedControlItem: UIControl {
         super.init(frame: frame)
         self.willPress = willPress
         self.didPressed = didPressed
-        label = UILabel(frame: CGRectZero)
+        
+        commonInit()
         label.textColor = appearance.textColor
         label.font = appearance.font
-        label.textAlignment = .Center
         label.text = text
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init (coder: aDecoder)
+        
+        commonInit()
+    }
+    
+    private func commonInit() {
+        label = UILabel(frame: CGRectZero)
+        label.textAlignment = .Center
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
         
@@ -66,10 +77,6 @@ class YSSegmentedControlItem: UIControl {
             options: [],
             metrics: nil,
             views: views))
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        super.init (coder: aDecoder)
     }
     
     // MARK: Events


### PR DESCRIPTION
**This builds on top of #9, so please merge that one first.**

This pull request implements `layoutSubviews` in order to reposition the subviews whenever the view lays out its subviews.

This ensures that the subviews are always laid out properly, and is especially useful when creating the `YSSegmentedControl` in a Storyboard, and running it on a different sized device than the canvas.
