### PR TITLE
Update selector line frame based on selectedIndex

### DIFF
--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -104,6 +104,8 @@ public class YSSegmentedControl: UIView {
     weak var delegate: YSSegmentedControlDelegate?
     public var action: YSSegmentedControlAction?
     
+    private var selectedIndex = 0
+    
     public var appearance: YSSegmentedControlAppearance! {
         didSet {
             self.draw()
@@ -211,8 +213,10 @@ public class YSSegmentedControl: UIView {
             width: frame.size.width,
             height: appearance.bottomLineHeight)
         
+        let target = width * CGFloat(selectedIndex)
+        
         selector.frame = CGRect (
-            x: selector.frame.origin.x,
+            x: target,
             y: frame.size.height - appearance.selectorHeight,
             width: width,
             height: appearance.selectorHeight)
@@ -236,6 +240,7 @@ public class YSSegmentedControl: UIView {
     // MARK: Select
     
     public func selectItem(at index: Int, withAnimation animation: Bool) {
+        self.selectedIndex = index
         moveSelector(at: index, withAnimation: animation)
         for item in items {
             if item == items[index] {


### PR DESCRIPTION
There was an issue with creating a `YSSegmentedControl` instance and using a frame of `.zero` and then using AutoLayout to constraint it, and setting the selected index before the `YSSegmentedControl` rendered. The selector line would not draw in the correct spot because `selector.frame.origin` in `layoutSubviews` was still 0.

This pull request uses the index of the selected item to draw the selector line.