### PR TITLE
Enhance YSSegmentedControlAppearance

### DIFF
--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -40,9 +40,9 @@ class TableViewController: UITableViewController {
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
     }
     
-    @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
+    @IBAction func didToggleselectorSpansLabelWidthSwitch(_ sender: UISwitch) {
         var appearance = segmented.appearance
-        appearance?.selectorSpansFullItemWidth = sender.isOn
+        appearance?.selectorSpansLabelWidth = sender.isOn
         segmented.appearance = appearance
     }
     

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -44,16 +44,16 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansFullItemWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cj7-PA-8So">
-                                                    <rect key="frame" x="8" y="8" width="214" height="27.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansLabelWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cj7-PA-8So">
+                                                    <rect key="frame" x="8" y="8" width="196.5" height="27.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YkY-hN-8dx">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="YkY-hN-8dx">
                                                     <rect key="frame" x="318" y="6" width="51" height="31"/>
                                                     <connections>
-                                                        <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="S4w-Ka-Spx"/>
+                                                        <action selector="didToggleselectorSpansLabelWidthSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="UuC-Wq-d8y"/>
                                                     </connections>
                                                 </switch>
                                             </subviews>

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -34,11 +34,13 @@ public struct YSSegmentedControlAppearance {
     
     /**
      Whether or not the selector spans the full width of the
-     YSSegmentedControlItem.
-     If set to true, the selector will span the entire width of the item;
-     if set to false, the selector will span the entire width of the label.
+     YSSegmentedControlItem's label.
+     If set to true, the selector will span the full width of the label;
+     if set to false, the selector will span the entire width of the item.
+     
+     Defaults to false.
      */
-    public var selectorSpansFullItemWidth: Bool
+    public var selectorSpansLabelWidth: Bool
 }
 
 // MARK: - Control Item
@@ -275,7 +277,7 @@ public class YSSegmentedControl: UIView {
             selectorHeight: 2,
             labelTopPadding: 0,
             selectorOffsetFromLabel: nil,
-            selectorSpansFullItemWidth: true)
+            selectorSpansLabelWidth: false)
     }
     
     // MARK: Select
@@ -317,11 +319,11 @@ public class YSSegmentedControl: UIView {
         
         let horizontalConstrainingView: UIView
         
-        if appearance.selectorSpansFullItemWidth {
-            horizontalConstrainingView = item
+        if appearance.selectorSpansLabelWidth {
+            horizontalConstrainingView = item.label
         }
         else {
-            horizontalConstrainingView = item.label
+            horizontalConstrainingView = item
         }
         
         selectorLeadingConstraint = NSLayoutConstraint(item: selector,


### PR DESCRIPTION
**Note: This builds on https://github.com/yemeksepeti/YSSegmentedControl/pull/15, so merge that one first in order to slim up the changes in this one.**

This pull request enhances the `YSSegmentedControlAppearance` struct by adding a few couple new options, and also enhances the demo application by adding in switches to toggle between various states of the segmented control's appearance.

# `YSSegmentedControlAppearance` Enhancements

### 1. `selectorOffsetFromLabel: CGFloat?`

*Default value: `nil`*

This new property allows for offsetting the selector from the bottom of the label, as opposed to positioning it at the bottom of the segmented control. This is optional, so if no value is specified then the selector will sit on the bottom of the segmented control as it did before this pull request. If a value is specified, then the selector will sit that many points below the bottom of the label inside the `YSSegmentedControlItem`.

### 2. `selectorSpansLabelWidth: Bool`

*Default value: `false`*

This new property allows for toggling between the selector spanning the width of the label or not. If this is set to `true`, then the selector will span the width of the **label** inside the `YSSegmentedControlItem`; and if this is set to `true`, ten the selector will span the full width of the `YSSegmentedControlItem`.

## Screenshots
<img width="487" alt="screen shot 2017-08-03 at 9 44 07 pm" src="https://user-images.githubusercontent.com/879038/28951105-e2d4d322-7896-11e7-8bed-26d8fe25069d.png">

In this screenshot, `selectorOffsetFromLabel` is set to a non-nil value of `0`, and `selectorSpansFullItemWidth` is set to `false`.

# Demo Enhancements

This enhances the demo view controller by adding an interface to configure the segmented control's appearance. It also changes the `ViewController` to a `TableViewController` to support many rows of configurable controls.

## Screenshots
![demo](https://user-images.githubusercontent.com/879038/28992194-1db23282-7964-11e7-876b-d4410d814110.gif)

