### PR TITLE
Add support to float labels on ends to edges of segmented control

### DIFF
--- a/YSSegmentedControl.podspec
+++ b/YSSegmentedControl.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "YSSegmentedControl"
-  s.version      = "0.2.3"
+  s.version      = "0.2.4"
   s.summary      = "Android style segmented control written in swift. Fully customisable."
 
   # This description is used to generate tags and improve search results.

--- a/YSSegmentedControl.xcodeproj/project.pbxproj
+++ b/YSSegmentedControl.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B28BBFB11BF24CB30064F127 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA61BF24CB30064F127 /* ViewController.swift */; };
+		B28BBFB11BF24CB30064F127 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA61BF24CB30064F127 /* TableViewController.swift */; };
 		B28BBFB21BF24CB30064F127 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28BBFA81BF24CB30064F127 /* AppDelegate.swift */; };
 		B28BBFB31BF24CB30064F127 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B28BBFA91BF24CB30064F127 /* LaunchScreen.xib */; };
 		B28BBFB41BF24CB30064F127 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B28BBFAB1BF24CB30064F127 /* Main.storyboard */; };
@@ -27,7 +27,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		B28BBFA61BF24CB30064F127 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B28BBFA61BF24CB30064F127 /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		B28BBFA81BF24CB30064F127 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B28BBFAA1BF24CB30064F127 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		B28BBFAC1BF24CB30064F127 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -61,7 +61,7 @@
 		B28BBFA51BF24CB30064F127 /* Demo */ = {
 			isa = PBXGroup;
 			children = (
-				B28BBFA61BF24CB30064F127 /* ViewController.swift */,
+				B28BBFA61BF24CB30064F127 /* TableViewController.swift */,
 			);
 			path = Demo;
 			sourceTree = "<group>";
@@ -234,7 +234,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B28BBFB21BF24CB30064F127 /* AppDelegate.swift in Sources */,
-				B28BBFB11BF24CB30064F127 /* ViewController.swift in Sources */,
+				B28BBFB11BF24CB30064F127 /* TableViewController.swift in Sources */,
 				B28BBFB71BF24CB30064F127 /* YSSegmentedControl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -30,6 +30,11 @@ class TableViewController: UITableViewController {
         }
         
         segmented.delegate = self
+        
+        var appearance = segmented.appearance
+        appearance?.textAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 16), NSForegroundColorAttributeName: UIColor.gray]
+        appearance?.selectedTextAttributes = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: 16), NSForegroundColorAttributeName: UIColor.black]
+        segmented.appearance = appearance
 
         navigationItem.titleView = segmented
         

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class TableViewController: UITableViewController {
 
     // MARK: Lifecycle
     
@@ -16,7 +16,6 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.title = "Demo"
 
         segmented.frame = CGRect(x: 0, y: 64, width: view.frame.size.width, height: 44)
         segmented.titles = ["First", "Second", "Third"]
@@ -25,7 +24,8 @@ class ViewController: UIViewController {
         }
         
         segmented.delegate = self
-        view.addSubview(segmented)
+
+        navigationItem.titleView = segmented
     }
     
     @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
     }
 }
 
-extension ViewController: YSSegmentedControlDelegate {
+extension TableViewController: YSSegmentedControlDelegate {
     func segmentedControl(_ segmentedControl: YSSegmentedControl, willPressItemAt index: Int) {
         print ("[Delegate] segmented will press \(index)")
     }

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -16,6 +16,8 @@ class TableViewController: UITableViewController {
     @IBOutlet weak var selectorOffsetFromLabelSwitch: UISwitch!
     @IBOutlet weak var selectorOffsetFromLabelValueLabel: UILabel!
     
+    @IBOutlet weak var labelsOnEndsFloatToEdgesSwitch: UISwitch!
+    
     // MARK: Lifecycle
     
     let segmented = YSSegmentedControl(frame: .zero, titles: [])
@@ -38,11 +40,7 @@ class TableViewController: UITableViewController {
 
         navigationItem.titleView = segmented
         
-        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
-        
-        selectorOffsetFromLabelStepper.value = Double(segmented.appearance.selectorOffsetFromLabel ?? 0)
-        selectorOffsetFromLabelSwitch.isOn = segmented.appearance.selectorOffsetFromLabel != nil
-        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
+        updateAppearanceConfigurationUI()
     }
     
     @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
@@ -64,6 +62,24 @@ class TableViewController: UITableViewController {
         var appearance = segmented.appearance
         appearance?.selectorOffsetFromLabel = CGFloat(sender.value)
         segmented.appearance = appearance
+    }
+    
+    @IBAction func didToggleLabelsOnEndsFloatToEdgesSwitch(_ sender: UISwitch) {
+        var appearance = segmented.appearance
+        appearance?.labelsOnEndsFloatToEdges = sender.isOn
+        segmented.appearance = appearance
+    }
+
+    // MARK: Helpers
+    
+    func updateAppearanceConfigurationUI() {
+        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
+        
+        selectorOffsetFromLabelStepper.value = Double(segmented.appearance.selectorOffsetFromLabel ?? 0)
+        selectorOffsetFromLabelSwitch.isOn = segmented.appearance.selectorOffsetFromLabel != nil
+        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
+        
+        labelsOnEndsFloatToEdgesSwitch.isOn = segmented.appearance.labelsOnEndsFloatToEdges
     }
 }
 

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -9,7 +9,13 @@
 import UIKit
 
 class TableViewController: UITableViewController {
-
+    
+    // MARK: Demo
+    
+    @IBOutlet weak var selectorOffsetFromLabelStepper: UIStepper!
+    @IBOutlet weak var selectorOffsetFromLabelSwitch: UISwitch!
+    @IBOutlet weak var selectorOffsetFromLabelValueLabel: UILabel!
+    
     // MARK: Lifecycle
     
     let segmented = YSSegmentedControl(frame: .zero, titles: [])
@@ -26,6 +32,8 @@ class TableViewController: UITableViewController {
         segmented.delegate = self
 
         navigationItem.titleView = segmented
+        
+        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
     }
     
     @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
@@ -36,7 +44,16 @@ class TableViewController: UITableViewController {
     
     @IBAction func didToggleSelectorOffsetFromLabelSwitch(_ sender: UISwitch) {
         var appearance = segmented.appearance
-        appearance?.selectorOffsetFromLabel = sender.isOn ? 2 : nil
+        appearance?.selectorOffsetFromLabel = sender.isOn ? CGFloat(selectorOffsetFromLabelStepper.value) : nil
+        segmented.appearance = appearance
+    }
+
+    @IBAction func didChageSelectorOffsetFromlabelStepper(_ sender: UIStepper) {
+        selectorOffsetFromLabelSwitch.isOn = true
+        selectorOffsetFromLabelValueLabel.text = "\(sender.value)"
+        
+        var appearance = segmented.appearance
+        appearance?.selectorOffsetFromLabel = CGFloat(sender.value)
         segmented.appearance = appearance
     }
 }

--- a/YSSegmentedControl/Demo/TableViewController.swift
+++ b/YSSegmentedControl/Demo/TableViewController.swift
@@ -34,6 +34,10 @@ class TableViewController: UITableViewController {
         navigationItem.titleView = segmented
         
         selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
+        
+        selectorOffsetFromLabelStepper.value = Double(segmented.appearance.selectorOffsetFromLabel ?? 0)
+        selectorOffsetFromLabelSwitch.isOn = segmented.appearance.selectorOffsetFromLabel != nil
+        selectorOffsetFromLabelValueLabel.text = "\(selectorOffsetFromLabelStepper.value)"
     }
     
     @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {

--- a/YSSegmentedControl/Demo/ViewController.swift
+++ b/YSSegmentedControl/Demo/ViewController.swift
@@ -34,6 +34,11 @@ class ViewController: UIViewController {
         segmented.appearance = appearance
     }
     
+    @IBAction func didToggleSelectorOffsetFromLabelSwitch(_ sender: UISwitch) {
+        var appearance = segmented.appearance
+        appearance?.selectorOffsetFromLabel = sender.isOn ? 2 : nil
+        segmented.appearance = appearance
+    }
 }
 
 extension ViewController: YSSegmentedControlDelegate {

--- a/YSSegmentedControl/Demo/ViewController.swift
+++ b/YSSegmentedControl/Demo/ViewController.swift
@@ -12,29 +12,28 @@ class ViewController: UIViewController {
 
     // MARK: Lifecycle
     
+    let segmented = YSSegmentedControl(frame: .zero, titles: [])
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(white: 240.0/255.0, alpha: 1)
         navigationItem.title = "Demo"
+
+        segmented.frame = CGRect(x: 0, y: 64, width: view.frame.size.width, height: 44)
+        segmented.titles = ["First", "Second", "Third"]
+        segmented.action = { control, index in
+            print ("segmented did pressed \(index)")
+        }
         
-        let segmented = YSSegmentedControl(
-            frame: CGRect(
-                x: 0,
-                y: 64,
-                width: view.frame.size.width,
-                height: 44),
-            titles: [
-                "First",
-                "Second",
-                "Third"
-            ],
-            action: {
-                control, index in
-                print ("segmented did pressed \(index)")
-            })
         segmented.delegate = self
         view.addSubview(segmented)
     }
+    
+    @IBAction func didToggleSelectorSpansFullItemWidthSwitch(_ sender: UISwitch) {
+        var appearance = segmented.appearance
+        appearance?.selectorSpansFullItemWidth = sender.isOn
+        segmented.appearance = appearance
+    }
+    
 }
 
 extension ViewController: YSSegmentedControlDelegate {

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Wwv-lb-7V5">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Wwv-lb-7V5">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -13,15 +18,15 @@
                         <viewControllerLayoutGuide type="bottom" id="Bq1-ud-FC4"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="vvK-VF-ak6">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <navigationItem key="navigationItem" id="OK5-fF-1mM"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="p0I-Kd-0mt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="246" y="774"/>
+            <point key="canvasLocation" x="481" y="773"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="3ea-eU-sLf">

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -6,65 +6,9 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="g39-DK-9tB">
-            <objects>
-                <viewController id="VTR-Tb-F2F" customClass="ViewController" customModule="YSSegmentedControl" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="LAM-vU-5PP"/>
-                        <viewControllerLayoutGuide type="bottom" id="Bq1-ud-FC4"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="vvK-VF-ak6">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansFullItemWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AQb-M4-fCx">
-                                <rect key="frame" x="16" y="178" width="214" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2as-26-5uL">
-                                <rect key="frame" x="310" y="173" width="51" height="31"/>
-                                <connections>
-                                    <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="VTR-Tb-F2F" eventType="valueChanged" id="bDR-UU-AIw"/>
-                                </connections>
-                            </switch>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorOffsetFromLabel (2)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zn0-QH-n4o">
-                                <rect key="frame" x="16" y="219" width="216" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xvd-ku-2QY">
-                                <rect key="frame" x="310" y="214" width="51" height="31"/>
-                                <connections>
-                                    <action selector="didToggleSelectorOffsetFromLabelSwitch:" destination="VTR-Tb-F2F" eventType="valueChanged" id="v6N-IX-L65"/>
-                                </connections>
-                            </switch>
-                        </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="zn0-QH-n4o" firstAttribute="leading" secondItem="AQb-M4-fCx" secondAttribute="leading" id="2lH-a0-noH"/>
-                            <constraint firstItem="AQb-M4-fCx" firstAttribute="top" secondItem="LAM-vU-5PP" secondAttribute="bottom" constant="114" id="6Nf-Iz-Fhu"/>
-                            <constraint firstItem="zn0-QH-n4o" firstAttribute="top" secondItem="AQb-M4-fCx" secondAttribute="bottom" constant="20" id="Sj5-if-gop"/>
-                            <constraint firstItem="2as-26-5uL" firstAttribute="centerY" secondItem="AQb-M4-fCx" secondAttribute="centerY" id="SjJ-0v-HDm"/>
-                            <constraint firstItem="xvd-ku-2QY" firstAttribute="trailing" secondItem="2as-26-5uL" secondAttribute="trailing" id="h9W-eC-QeD"/>
-                            <constraint firstItem="xvd-ku-2QY" firstAttribute="centerY" secondItem="zn0-QH-n4o" secondAttribute="centerY" id="ihb-3o-gPU"/>
-                            <constraint firstItem="2as-26-5uL" firstAttribute="trailing" secondItem="vvK-VF-ak6" secondAttribute="trailingMargin" id="owm-e9-8hB"/>
-                            <constraint firstItem="AQb-M4-fCx" firstAttribute="leading" secondItem="vvK-VF-ak6" secondAttribute="leadingMargin" id="rok-g6-kWh"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="OK5-fF-1mM"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="p0I-Kd-0mt" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="481" y="773"/>
-        </scene>
         <!--Navigation Controller-->
         <scene sceneID="3ea-eU-sLf">
             <objects>
@@ -74,12 +18,41 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
-                        <segue destination="VTR-Tb-F2F" kind="relationship" relationship="rootViewController" id="PhC-Qh-ky9"/>
+                        <segue destination="DNs-Uf-ScM" kind="relationship" relationship="rootViewController" id="Ync-ja-EK5"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tZi-Fz-fVn" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-410" y="774"/>
+        </scene>
+        <!--Table View Controller-->
+        <scene sceneID="gTT-st-N6h">
+            <objects>
+                <tableViewController id="DNs-Uf-ScM" customClass="TableViewController" customModule="YSSegmentedControl" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="CDN-yz-PUA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="LGj-qc-bbo">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LGj-qc-bbo" id="eu6-QD-iyM">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="DNs-Uf-ScM" id="47K-WW-Nub"/>
+                            <outlet property="delegate" destination="DNs-Uf-ScM" id="x3p-NO-uE0"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="HIx-N7-63y"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Cig-mt-BGt" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="350" y="773"/>
         </scene>
     </scenes>
 </document>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,7 +21,27 @@
                     <view key="view" contentMode="scaleToFill" id="vvK-VF-ak6">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansFullItemWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AQb-M4-fCx">
+                                <rect key="frame" x="16" y="178" width="214" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2as-26-5uL">
+                                <rect key="frame" x="310" y="173" width="51" height="31"/>
+                                <connections>
+                                    <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="VTR-Tb-F2F" eventType="valueChanged" id="bDR-UU-AIw"/>
+                                </connections>
+                            </switch>
+                        </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="AQb-M4-fCx" firstAttribute="top" secondItem="LAM-vU-5PP" secondAttribute="bottom" constant="114" id="6Nf-Iz-Fhu"/>
+                            <constraint firstItem="2as-26-5uL" firstAttribute="centerY" secondItem="AQb-M4-fCx" secondAttribute="centerY" id="SjJ-0v-HDm"/>
+                            <constraint firstItem="2as-26-5uL" firstAttribute="trailing" secondItem="vvK-VF-ak6" secondAttribute="trailingMargin" id="owm-e9-8hB"/>
+                            <constraint firstItem="AQb-M4-fCx" firstAttribute="leading" secondItem="vvK-VF-ak6" secondAttribute="leadingMargin" id="rok-g6-kWh"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="OK5-fF-1mM"/>
                 </viewController>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -34,11 +34,27 @@
                                     <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="VTR-Tb-F2F" eventType="valueChanged" id="bDR-UU-AIw"/>
                                 </connections>
                             </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorOffsetFromLabel (2)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zn0-QH-n4o">
+                                <rect key="frame" x="16" y="219" width="216" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xvd-ku-2QY">
+                                <rect key="frame" x="310" y="214" width="51" height="31"/>
+                                <connections>
+                                    <action selector="didToggleSelectorOffsetFromLabelSwitch:" destination="VTR-Tb-F2F" eventType="valueChanged" id="v6N-IX-L65"/>
+                                </connections>
+                            </switch>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="zn0-QH-n4o" firstAttribute="leading" secondItem="AQb-M4-fCx" secondAttribute="leading" id="2lH-a0-noH"/>
                             <constraint firstItem="AQb-M4-fCx" firstAttribute="top" secondItem="LAM-vU-5PP" secondAttribute="bottom" constant="114" id="6Nf-Iz-Fhu"/>
+                            <constraint firstItem="zn0-QH-n4o" firstAttribute="top" secondItem="AQb-M4-fCx" secondAttribute="bottom" constant="20" id="Sj5-if-gop"/>
                             <constraint firstItem="2as-26-5uL" firstAttribute="centerY" secondItem="AQb-M4-fCx" secondAttribute="centerY" id="SjJ-0v-HDm"/>
+                            <constraint firstItem="xvd-ku-2QY" firstAttribute="trailing" secondItem="2as-26-5uL" secondAttribute="trailing" id="h9W-eC-QeD"/>
+                            <constraint firstItem="xvd-ku-2QY" firstAttribute="centerY" secondItem="zn0-QH-n4o" secondAttribute="centerY" id="ihb-3o-gPU"/>
                             <constraint firstItem="2as-26-5uL" firstAttribute="trailing" secondItem="vvK-VF-ak6" secondAttribute="trailingMargin" id="owm-e9-8hB"/>
                             <constraint firstItem="AQb-M4-fCx" firstAttribute="leading" secondItem="vvK-VF-ak6" secondAttribute="leadingMargin" id="rok-g6-kWh"/>
                         </constraints>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -111,6 +111,35 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Tjf-ch-ALz">
+                                        <rect key="frame" x="0.0" y="120" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Tjf-ch-ALz" id="Akb-0w-Gpf">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="labelsOnEndsFloatToEdges" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q26-Ps-DNw">
+                                                    <rect key="frame" x="8" y="8" width="208.5" height="27.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1rn-n8-Gim">
+                                                    <rect key="frame" x="318" y="6.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="didToggleLabelsOnEndsFloatToEdgesSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="A9w-rV-Xcn"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="q26-Ps-DNw" firstAttribute="leading" secondItem="Akb-0w-Gpf" secondAttribute="leadingMargin" id="NYi-ch-X2e"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="q26-Ps-DNw" secondAttribute="bottom" id="bfx-v6-br0"/>
+                                                <constraint firstItem="1rn-n8-Gim" firstAttribute="centerY" secondItem="q26-Ps-DNw" secondAttribute="centerY" id="gEX-lI-J0h"/>
+                                                <constraint firstItem="1rn-n8-Gim" firstAttribute="trailing" secondItem="Akb-0w-Gpf" secondAttribute="trailingMargin" id="iOK-3Y-4oW"/>
+                                                <constraint firstItem="q26-Ps-DNw" firstAttribute="top" secondItem="Akb-0w-Gpf" secondAttribute="topMargin" id="raA-31-shz"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -121,6 +150,7 @@
                     </tableView>
                     <navigationItem key="navigationItem" id="HIx-N7-63y"/>
                     <connections>
+                        <outlet property="labelsOnEndsFloatToEdgesSwitch" destination="1rn-n8-Gim" id="1ca-ga-wCZ"/>
                         <outlet property="selectorOffsetFromLabelStepper" destination="5TY-It-D6n" id="4Qn-Sm-zl7"/>
                         <outlet property="selectorOffsetFromLabelSwitch" destination="hRx-s7-rUd" id="rMH-ic-hkg"/>
                         <outlet property="selectorOffsetFromLabelValueLabel" destination="Mzl-12-ShV" id="Xg1-hd-VEJ"/>

--- a/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
+++ b/YSSegmentedControl/SupportingFiles/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,30 +30,105 @@
         <scene sceneID="gTT-st-N6h">
             <objects>
                 <tableViewController id="DNs-Uf-ScM" customClass="TableViewController" customModule="YSSegmentedControl" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="CDN-yz-PUA">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="CDN-yz-PUA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="LGj-qc-bbo">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LGj-qc-bbo" id="eu6-QD-iyM">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
+                        <sections>
+                            <tableViewSection id="7eX-e6-5TY">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="LGj-qc-bbo">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LGj-qc-bbo" id="eu6-QD-iyM">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorSpansFullItemWidth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cj7-PA-8So">
+                                                    <rect key="frame" x="8" y="8" width="214" height="27.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YkY-hN-8dx">
+                                                    <rect key="frame" x="318" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="didToggleSelectorSpansFullItemWidthSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="S4w-Ka-Spx"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="YkY-hN-8dx" firstAttribute="centerY" secondItem="Cj7-PA-8So" secondAttribute="centerY" id="BBJ-wl-qhB"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Cj7-PA-8So" secondAttribute="bottom" id="Csm-ti-vnT"/>
+                                                <constraint firstItem="Cj7-PA-8So" firstAttribute="top" secondItem="eu6-QD-iyM" secondAttribute="topMargin" id="OqY-z3-Hx4"/>
+                                                <constraint firstItem="Cj7-PA-8So" firstAttribute="leading" secondItem="eu6-QD-iyM" secondAttribute="leadingMargin" id="er7-0P-cZw"/>
+                                                <constraint firstItem="YkY-hN-8dx" firstAttribute="trailing" secondItem="eu6-QD-iyM" secondAttribute="trailingMargin" id="ymo-NR-6Sr"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="76" id="fgH-fF-iXU">
+                                        <rect key="frame" x="0.0" y="44" width="375" height="76"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fgH-fF-iXU" id="KzF-qm-fWO">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="75.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="selectorOffsetFromLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gBj-lX-mgM">
+                                                    <rect key="frame" x="8" y="8" width="190" height="22"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="hRx-s7-rUd">
+                                                    <rect key="frame" x="318" y="3.5" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="didToggleSelectorOffsetFromLabelSwitch:" destination="DNs-Uf-ScM" eventType="valueChanged" id="Wxk-da-eZz"/>
+                                                    </connections>
+                                                </switch>
+                                                <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="5TY-It-D6n">
+                                                    <rect key="frame" x="8" y="38.5" width="94" height="29"/>
+                                                    <connections>
+                                                        <action selector="didChageSelectorOffsetFromlabelStepper:" destination="DNs-Uf-ScM" eventType="valueChanged" id="Oxd-13-M0V"/>
+                                                    </connections>
+                                                </stepper>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mzl-12-ShV">
+                                                    <rect key="frame" x="110" y="43" width="42" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="5TY-It-D6n" firstAttribute="leading" secondItem="KzF-qm-fWO" secondAttribute="leadingMargin" id="4gH-mL-cFy"/>
+                                                <constraint firstItem="5TY-It-D6n" firstAttribute="top" secondItem="gBj-lX-mgM" secondAttribute="bottom" constant="8.5" id="5PN-eW-jMM"/>
+                                                <constraint firstItem="Mzl-12-ShV" firstAttribute="centerY" secondItem="5TY-It-D6n" secondAttribute="centerY" id="8f7-Wh-44T"/>
+                                                <constraint firstItem="Mzl-12-ShV" firstAttribute="leading" secondItem="5TY-It-D6n" secondAttribute="trailing" constant="8" id="IG2-oB-3dL"/>
+                                                <constraint firstItem="gBj-lX-mgM" firstAttribute="top" secondItem="KzF-qm-fWO" secondAttribute="topMargin" id="NwL-aR-vSm"/>
+                                                <constraint firstItem="hRx-s7-rUd" firstAttribute="trailing" secondItem="KzF-qm-fWO" secondAttribute="trailingMargin" id="PHc-oU-Feh"/>
+                                                <constraint firstItem="hRx-s7-rUd" firstAttribute="centerY" secondItem="gBj-lX-mgM" secondAttribute="centerY" id="ZbQ-ax-1CN"/>
+                                                <constraint firstItem="gBj-lX-mgM" firstAttribute="leading" secondItem="KzF-qm-fWO" secondAttribute="leadingMargin" id="rUB-C1-mHG"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="5TY-It-D6n" secondAttribute="bottom" id="wGq-09-jGv"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
                         <connections>
                             <outlet property="dataSource" destination="DNs-Uf-ScM" id="47K-WW-Nub"/>
                             <outlet property="delegate" destination="DNs-Uf-ScM" id="x3p-NO-uE0"/>
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="HIx-N7-63y"/>
+                    <connections>
+                        <outlet property="selectorOffsetFromLabelStepper" destination="5TY-It-D6n" id="4Qn-Sm-zl7"/>
+                        <outlet property="selectorOffsetFromLabelSwitch" destination="hRx-s7-rUd" id="rMH-ic-hkg"/>
+                        <outlet property="selectorOffsetFromLabelValueLabel" destination="Mzl-12-ShV" id="Xg1-hd-VEJ"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Cig-mt-BGt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="350" y="773"/>
+            <point key="canvasLocation" x="349.60000000000002" y="772.26386806596713"/>
         </scene>
     </scenes>
 </document>

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -22,6 +22,23 @@ public struct YSSegmentedControlAppearance {
     public var bottomLineHeight: CGFloat
     public var selectorHeight: CGFloat
     public var labelTopPadding: CGFloat
+    
+    /**
+     The distance between the top of the selector and the bottom
+     of the label.
+     If this is nil, then the selector will be anchored on the bottom
+     of the segmented control;
+     otherwise the selector will be this distance from the bottom of the label.
+     */
+    public var selectorOffsetFromLabel: CGFloat?
+    
+    /**
+     Whether or not the selector spans the full width of the
+     YSSegmentedControlItem.
+     If set to true, the selector will span the entire width of the item;
+     if set to false, the selector will span the entire width of the label.
+     */
+    public var selectorSpansFullItemWidth: Bool
 }
 
 // MARK: - Control Item
@@ -249,7 +266,9 @@ public class YSSegmentedControl: UIView {
             selectorColor: .black,
             bottomLineHeight: 0.5,
             selectorHeight: 2,
-            labelTopPadding: 0)
+            labelTopPadding: 0,
+            selectorOffsetFromLabel: nil,
+            selectorSpansFullItemWidth: true)
     }
     
     // MARK: Select

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -99,11 +99,11 @@ class YSSegmentedControlItem: UIControl {
                                          constant: 0.0))
         
         let views: [String: Any] = ["label": label]
-        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(>=0)-[label]-(<=0)-|",
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(>=0)-[label]-(>=0)-|",
                                                       options: [],
                                                       metrics: nil,
                                                       views: views))
-        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-(>=0)-[label]-(<=0)-|",
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-(>=0)-[label]-(>=0)-|",
                                                       options: [],
                                                       metrics: nil,
                                                       views: views))

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -13,10 +13,10 @@ import UIKit
 public struct YSSegmentedControlAppearance {
     public var backgroundColor: UIColor
     public var selectedBackgroundColor: UIColor
-    public var textColor: UIColor
-    public var font: UIFont
-    public var selectedTextColor: UIColor
-    public var selectedFont: UIFont
+    
+    public var textAttributes: [String : Any]
+    public var selectedTextAttributes: [String : Any]
+    
     public var bottomLineColor: UIColor
     public var selectorColor: UIColor
     public var bottomLineHeight: CGFloat
@@ -51,6 +51,7 @@ class YSSegmentedControlItem: UIControl {
     
     private var willPress: YSSegmentedControlItemAction?
     private var didPress: YSSegmentedControlItemAction?
+    
     var label: UILabel!
     
     // MARK: Init
@@ -65,9 +66,7 @@ class YSSegmentedControlItem: UIControl {
         self.didPress = didPress
         
         commonInit()
-        label.textColor = appearance.textColor
-        label.font = appearance.font
-        label.text = text
+        label.attributedText = NSAttributedString(string: text, attributes: appearance.textAttributes)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -107,6 +106,17 @@ class YSSegmentedControlItem: UIControl {
                                                       options: [],
                                                       metrics: nil,
                                                       views: views))
+    }
+    
+    // MARK: UI Helpers
+    
+    func updateLabelAttributes(_ attributes: [String : Any]) {
+        guard let labelText = label.text else {
+            return
+        }
+        
+        label.attributedText = NSAttributedString(string: labelText,
+                                                  attributes: attributes)
     }
     
     // MARK: Events
@@ -265,10 +275,8 @@ public class YSSegmentedControl: UIView {
         appearance = YSSegmentedControlAppearance(
             backgroundColor: .clear,
             selectedBackgroundColor: .clear,
-            textColor: .gray,
-            font: .systemFont(ofSize: 15),
-            selectedTextColor: .black,
-            selectedFont: .systemFont(ofSize: 15),
+            textAttributes: [:],
+            selectedTextAttributes: [:],
             bottomLineColor: .black,
             selectorColor: .black,
             bottomLineHeight: 0.5,
@@ -285,12 +293,10 @@ public class YSSegmentedControl: UIView {
         moveSelector(at: index, withAnimation: animation)
         for item in items {
             if item == items[index] {
-                item.label.textColor = appearance.selectedTextColor
-                item.label.font = appearance.selectedFont
+                item.updateLabelAttributes(appearance.selectedTextAttributes)
                 item.backgroundColor = appearance.selectedBackgroundColor
             } else {
-                item.label.textColor = appearance.textColor
-                item.label.font = appearance.font
+                item.updateLabelAttributes(appearance.textAttributes)
                 item.backgroundColor = appearance.backgroundColor
             }
         }

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -317,7 +317,14 @@ public class YSSegmentedControl: UIView {
             removeConstraint(selectorLeadingConstraint)
         }
         
-        let item = items[selectedIndex]
+        let item: UIView
+            
+        if appearance.selectorSpansFullItemWidth {
+            item = items[selectedIndex]
+        }
+        else {
+            item = items[selectedIndex].label
+        }
         
         selectorLeadingConstraint = NSLayoutConstraint(item: selector,
                                                        attribute: .leading,

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -162,6 +162,7 @@ public class YSSegmentedControl: UIView {
     
     fileprivate var selectorLeadingConstraint: NSLayoutConstraint?
     fileprivate var selectorWidthConstraint: NSLayoutConstraint?
+    fileprivate var selectorBottomConstraint: NSLayoutConstraint?
     
     // MARK: Init
     
@@ -232,14 +233,6 @@ public class YSSegmentedControl: UIView {
                                          attribute: .notAnAttribute,
                                          multiplier: 1.0,
                                          constant: appearance.selectorHeight))
-        
-        addConstraint(NSLayoutConstraint(item: selector,
-                                         attribute: .bottom,
-                                         relatedBy: .equal,
-                                         toItem: self,
-                                         attribute: .bottom,
-                                         multiplier: 1.0,
-                                         constant: 0))
         
         selectItem(at: selectedIndex, withAnimation: true)
         
@@ -316,20 +309,25 @@ public class YSSegmentedControl: UIView {
         if let selectorLeadingConstraint = selectorLeadingConstraint {
             removeConstraint(selectorLeadingConstraint)
         }
+        if let selectorBottomConstraint = selectorBottomConstraint {
+            removeConstraint(selectorBottomConstraint)
+        }
         
-        let item: UIView
-            
+        let item = items[selectedIndex]
+        
+        let horizontalConstrainingView: UIView
+        
         if appearance.selectorSpansFullItemWidth {
-            item = items[selectedIndex]
+            horizontalConstrainingView = item
         }
         else {
-            item = items[selectedIndex].label
+            horizontalConstrainingView = item.label
         }
         
         selectorLeadingConstraint = NSLayoutConstraint(item: selector,
                                                        attribute: .leading,
                                                        relatedBy: .equal,
-                                                       toItem: item,
+                                                       toItem: horizontalConstrainingView,
                                                        attribute: .leading,
                                                        multiplier: 1.0,
                                                        constant: 0)
@@ -337,12 +335,32 @@ public class YSSegmentedControl: UIView {
         selectorWidthConstraint = NSLayoutConstraint(item: selector,
                                                      attribute: .width,
                                                      relatedBy: .equal,
-                                                     toItem: item,
+                                                     toItem: horizontalConstrainingView,
                                                      attribute: .width,
                                                      multiplier: 1.0,
                                                      constant: 0)
         
-        self.addConstraints([self.selectorWidthConstraint!, self.selectorLeadingConstraint!])
+        if let selectorOffsetFromLabel = appearance.selectorOffsetFromLabel {
+            selectorBottomConstraint = NSLayoutConstraint(item: selector,
+                                                          attribute: .top,
+                                                          relatedBy: .equal,
+                                                          toItem: item.label,
+                                                          attribute: .bottom,
+                                                          multiplier: 1.0,
+                                                          constant: selectorOffsetFromLabel)
+        }
+        else {
+            selectorBottomConstraint = NSLayoutConstraint(item: selector,
+                                                          attribute: .bottom,
+                                                          relatedBy: .equal,
+                                                          toItem: self,
+                                                          attribute: .bottom,
+                                                          multiplier: 1.0,
+                                                          constant: 0)
+        }
+        
+        
+        addConstraints([selectorWidthConstraint!, selectorLeadingConstraint!, selectorBottomConstraint!])
         
         UIView.animate(withDuration: animation ? 0.3 : 0,
                        delay: 0,

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -21,7 +21,7 @@ public struct YSSegmentedControlAppearance {
     public var selectorColor: UIColor
     public var bottomLineHeight: CGFloat
     public var selectorHeight: CGFloat
-    public var labelTopPadding: CGFloat
+    public var itemTopPadding: CGFloat
     
     /**
      The distance between the top of the selector and the bottom
@@ -303,9 +303,9 @@ public class YSSegmentedControl: UIView {
         for item in items {
             item.frame = CGRect(
                 x: currentX,
-                y: appearance.labelTopPadding,
+                y: appearance.itemTopPadding,
                 width: width,
-                height: frame.size.height - appearance.labelTopPadding)
+                height: frame.size.height - appearance.itemTopPadding)
             currentX += width
         }
         
@@ -326,7 +326,7 @@ public class YSSegmentedControl: UIView {
             selectorColor: .black,
             bottomLineHeight: 0.5,
             selectorHeight: 2,
-            labelTopPadding: 0,
+            itemTopPadding: 0,
             selectorOffsetFromLabel: nil,
             selectorSpansFullItemWidth: true,
             labelsOnEndsFloatToEdges: false)

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -304,6 +304,10 @@ public class YSSegmentedControl: UIView {
     }
     
     private func moveSelector(at index: Int, withAnimation animation: Bool) {
+        guard items.count > selectedIndex else {
+            return
+        }
+        
         layoutIfNeeded()
 
         if let selectorWidthConstraint = selectorWidthConstraint {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -104,6 +104,8 @@ public class YSSegmentedControl: UIView {
     weak var delegate: YSSegmentedControlDelegate?
     public var action: YSSegmentedControlAction?
     
+    private var selectedIndex = 0
+    
     public var appearance: YSSegmentedControlAppearance! {
         didSet {
             self.draw()
@@ -211,8 +213,10 @@ public class YSSegmentedControl: UIView {
             width: frame.size.width,
             height: appearance.bottomLineHeight)
         
+        let target = width * CGFloat(selectedIndex)
+        
         selector.frame = CGRect (
-            x: selector.frame.origin.x,
+            x: target,
             y: frame.size.height - appearance.selectorHeight,
             width: width,
             height: appearance.selectorHeight)
@@ -236,6 +240,7 @@ public class YSSegmentedControl: UIView {
     // MARK: Select
     
     public func selectItem(at index: Int, withAnimation animation: Bool) {
+        self.selectedIndex = index
         moveSelector(at: index, withAnimation: animation)
         for item in items {
             if item == items[index] {

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -65,15 +65,30 @@ class YSSegmentedControlItem: UIControl {
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
         
+        addConstraint(NSLayoutConstraint(item: label,
+                                         attribute: .centerX,
+                                         relatedBy: .equal,
+                                         toItem: self,
+                                         attribute: .centerX,
+                                         multiplier: 1.0,
+                                         constant: 0.0))
+        addConstraint(NSLayoutConstraint(item: label,
+                                         attribute: .centerY,
+                                         relatedBy: .equal,
+                                         toItem: self,
+                                         attribute: .centerY,
+                                         multiplier: 1.0,
+                                         constant: 0.0))
+        
         let views: [String: Any] = ["label": label]
-        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[label]|",
-            options: [],
-            metrics: nil,
-            views: views))
-        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[label]|",
-            options: [],
-            metrics: nil,
-            views: views))
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-(>=0)-[label]-(<=0)-|",
+                                                      options: [],
+                                                      metrics: nil,
+                                                      views: views))
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-(>=0)-[label]-(<=0)-|",
+                                                      options: [],
+                                                      metrics: nil,
+                                                      views: views))
     }
     
     // MARK: Events

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -89,6 +89,7 @@ class YSSegmentedControlItem: UIControl {
                                          attribute: .centerX,
                                          multiplier: 1.0,
                                          constant: 0.0))
+
         addConstraint(NSLayoutConstraint(item: label,
                                          attribute: .centerY,
                                          relatedBy: .equal,

--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -160,6 +160,9 @@ public class YSSegmentedControl: UIView {
     var selector = UIView()
     var bottomLine = CALayer()
     
+    fileprivate var selectorLeadingConstraint: NSLayoutConstraint?
+    fileprivate var selectorWidthConstraint: NSLayoutConstraint?
+    
     // MARK: Init
     
     public init (frame: CGRect, titles: [String], action: YSSegmentedControlAction? = nil) {
@@ -216,9 +219,27 @@ public class YSSegmentedControl: UIView {
         // bottom line
         bottomLine.backgroundColor = appearance.bottomLineColor.cgColor
         layer.addSublayer(bottomLine)
+        
         // selector
+        selector.translatesAutoresizingMaskIntoConstraints = false
         selector.backgroundColor = appearance.selectorColor
         addSubview(selector)
+        
+        addConstraint(NSLayoutConstraint(item: selector,
+                                         attribute: .height,
+                                         relatedBy: .equal,
+                                         toItem: nil,
+                                         attribute: .notAnAttribute,
+                                         multiplier: 1.0,
+                                         constant: appearance.selectorHeight))
+        
+        addConstraint(NSLayoutConstraint(item: selector,
+                                         attribute: .bottom,
+                                         relatedBy: .equal,
+                                         toItem: self,
+                                         attribute: .bottom,
+                                         multiplier: 1.0,
+                                         constant: 0))
         
         selectItem(at: selectedIndex, withAnimation: true)
         
@@ -245,14 +266,6 @@ public class YSSegmentedControl: UIView {
             y: frame.size.height - appearance.bottomLineHeight,
             width: frame.size.width,
             height: appearance.bottomLineHeight)
-        
-        let target = width * CGFloat(selectedIndex)
-        
-        selector.frame = CGRect (
-            x: target,
-            y: frame.size.height - appearance.selectorHeight,
-            width: width,
-            height: appearance.selectorHeight)
     }
     
     private func defaultAppearance() {
@@ -291,8 +304,35 @@ public class YSSegmentedControl: UIView {
     }
     
     private func moveSelector(at index: Int, withAnimation animation: Bool) {
-        let width = frame.size.width / CGFloat(items.count)
-        let target = width * CGFloat(index)
+        layoutIfNeeded()
+
+        if let selectorWidthConstraint = selectorWidthConstraint {
+            removeConstraint(selectorWidthConstraint)
+        }
+        if let selectorLeadingConstraint = selectorLeadingConstraint {
+            removeConstraint(selectorLeadingConstraint)
+        }
+        
+        let item = items[selectedIndex]
+        
+        selectorLeadingConstraint = NSLayoutConstraint(item: selector,
+                                                       attribute: .leading,
+                                                       relatedBy: .equal,
+                                                       toItem: item,
+                                                       attribute: .leading,
+                                                       multiplier: 1.0,
+                                                       constant: 0)
+        
+        selectorWidthConstraint = NSLayoutConstraint(item: selector,
+                                                     attribute: .width,
+                                                     relatedBy: .equal,
+                                                     toItem: item,
+                                                     attribute: .width,
+                                                     multiplier: 1.0,
+                                                     constant: 0)
+        
+        self.addConstraints([self.selectorWidthConstraint!, self.selectorLeadingConstraint!])
+        
         UIView.animate(withDuration: animation ? 0.3 : 0,
                        delay: 0,
                        usingSpringWithDamping: 1,
@@ -300,7 +340,8 @@ public class YSSegmentedControl: UIView {
                        options: [],
                        animations: {
                         [unowned self] in
-                        self.selector.frame.origin.x = target
+                        
+                        self.layoutIfNeeded()
             },
                        completion: nil)
     }


### PR DESCRIPTION
**Note: This builds on https://github.com/yemeksepeti/YSSegmentedControl/pull/17, so merge that one first in order to slim up the changes in this one.**

This pull request enhances the `YSSegmentedControlAppearance` struct by adding a new construct for floating the labels on the ends of the segmented control to the edges of the segmented control, as opposed to being centered.

**This also changes a property name from `labelTopPadding` to `itemTopPadding`. This was done because the top padding is applied to the item itself, not the label inside the item.**

# New Properties

### 1.`labelsOnEndsFloatToEdges: Bool`

*Default value: `false`*

This new property allows for making the labels on either end of the segmented control float to the edges of the segmented control. Setting this to `true` makes the labels float to the edges (as seen in the screenshot below); and setting this to `false` makes the labels center aligned.

# Screenshots
<img width="459" alt="scerenshot-edges" src="https://user-images.githubusercontent.com/879038/28976842-8d723b0a-790d-11e7-9662-d8c760544760.png">
