### PR TITLE
Fix ''delegate' is inaccessable due to 'internal' protection level'

### DIFF
--- a/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
+++ b/YSSegmentedControl/YSSegmentedControl/YSSegmentedControl.swift
@@ -171,7 +171,7 @@ public class YSSegmentedControl: UIView {
     
     // MARK: Properties
     
-    weak var delegate: YSSegmentedControlDelegate?
+    public weak var delegate: YSSegmentedControlDelegate?
     public var action: YSSegmentedControlAction?
     
     private var selectedIndex = 0


### PR DESCRIPTION
Fix protection level issue with delegate in YSSegmentedControl for swift 4